### PR TITLE
Add measurement quality data to the lua range finder driver interface.

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -266,6 +266,7 @@ public:
     float distance_orient(enum Rotation orientation) const;
     uint16_t distance_cm_orient(enum Rotation orientation) const;
     int8_t signal_quality_pct_orient(enum Rotation orientation) const;
+    void distance_cm_orient_ex(enum Rotation orientation, uint16_t &dist_cm, int8_t &signal_quality_pct) const;
     int16_t max_distance_cm_orient(enum Rotation orientation) const;
     int16_t min_distance_cm_orient(enum Rotation orientation) const;
     int16_t ground_clearance_cm_orient(enum Rotation orientation) const;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -39,6 +39,7 @@ public:
     // Returns false if scripting backing hasn't been setup
     // Get distance from lua script
     virtual bool handle_script_msg(float dist_m) { return false; }
+    virtual bool handle_script_msg_ex(float dist_m, float signal_quality_pct) { return false; }
 #endif
 
 #if HAL_MSP_RANGEFINDER_ENABLED

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Lua.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Lua.cpp
@@ -22,7 +22,7 @@
 
 // constructor
 AP_RangeFinder_Lua::AP_RangeFinder_Lua(RangeFinder::RangeFinder_State &_state, AP_RangeFinder_Params &_params) :
-    AP_RangeFinder_Backend(_state, _params)
+    AP_RangeFinder_Backend(_state, _params), _distance_m(0.0f), _signal_quality_pct(-1)
 {
     set_status(RangeFinder::Status::NoData);
 }
@@ -31,11 +31,40 @@ AP_RangeFinder_Lua::AP_RangeFinder_Lua(RangeFinder::RangeFinder_State &_state, A
 // Set the distance based on a Lua Script
 bool AP_RangeFinder_Lua::handle_script_msg(float dist_m)
 {
+    return handle_script_msg_ex(dist_m, -1.0f);
+}
+
+
+// Set the distance and signal_quality based on a Lua Script.
+// If the signal_quality_pct argument is an int8_t from lua, then
+// things don't work. Not sure why but using a float works better.
+bool AP_RangeFinder_Lua::handle_script_msg_ex(float dist_m, float signal_quality_pct)
+{
     state.last_reading_ms = AP_HAL::millis();
     _distance_m = dist_m;
+
+    // Trying to set a bogus signal_quality is like having no signal_quality data.
+    _signal_quality_pct = (signal_quality_pct >= 0.0f && signal_quality_pct <= 100.0f) ?
+            static_cast<int8_t>(signal_quality_pct) : -1;
     return true;
 }
 
+bool AP_RangeFinder_Lua::get_signal_quality_pct(int8_t &quality_pct) const
+{
+    // Status and distance are updated via a periodic update routine. signal_quality
+    // is returned via this overridden virtual method. It seems that there is
+    // a good chance that the distance measurement and the signal_quaqlity value can
+    // get out of sync. For example if a hardware driver collects both distance and
+    // signal_quality and then a client queries the distance before the update routine
+    // runs, then the client will get and old distance with a new signal_quality.
+    // signal_quality should really be in the state structure along with distance.
+
+    // Just return the signal_quality when asked.
+    quality_pct = _signal_quality_pct;
+
+    // A value of -1 (no signal_quality) causes a false return.
+    return quality_pct >= 0;
+}
 
 // update the state of the sensor
 void AP_RangeFinder_Lua::update(void)
@@ -45,7 +74,13 @@ void AP_RangeFinder_Lua::update(void)
     if (AP_HAL::millis() - state.last_reading_ms > AP_RANGEFINDER_LUA_TIMEOUT_MS) {
         set_status(RangeFinder::Status::NoData);
         state.distance_m = 0.0f;
+        _signal_quality_pct = -1; // no signal_quality also
     } else {
+
+        // Move distance into the state structure. The status is updated based
+        // on if the distance is outside of min and max. Note: signal_quality provides levels
+        // of goodness for a Status::Good measurement. It is possible to have a Status::Good
+        // measurement with a signal_quality of 0.
         state.distance_m = _distance_m;
         update_status();
     }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Lua.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Lua.h
@@ -21,14 +21,19 @@ public:
 
     // Get update from Lua script
     bool handle_script_msg(float dist_m) override;
+    bool handle_script_msg_ex(float dist_m, float signal_quality_pct) override;
 
     MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
         return MAV_DISTANCE_SENSOR_UNKNOWN;
     }
 
+    // Return the last signal_quality that the driver returned
+    bool get_signal_quality_pct(int8_t &quality_pct) const override WARN_IF_UNUSED;
+
 private:
 
-    float _distance_m;   // stored data from lua script:
+    float _distance_m;          // stored data from lua script:
+    int8_t _signal_quality_pct; // stored data from lua script:
 };
 
 #endif  // AP_RANGEFINDER_LUA_ENABLED

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2429,6 +2429,12 @@ function terrain:enabled() end
 ---@class AP_RangeFinder_Backend_ud
 local AP_RangeFinder_Backend_ud = {}
 
+-- Send distance and signal_quality to lua rangefinder backend. Returns false if failed
+---@param distance_m number
+---@param signal_quality_pct number
+---@return boolean
+function AP_RangeFinder_Backend_ud:handle_script_msg_ex(distance_m, signal_quality_pct) end
+
 -- Send distance to lua rangefinder backend. Returns false if failed
 ---@param distance number
 ---@return boolean
@@ -2491,7 +2497,8 @@ function rangefinder:max_distance_cm_orient(orientation) end
 
 -- desc
 ---@param orientation integer
----@return integer
+---@return integer -- distance_cm
+---@return integer -- signal_quality_pct
 function rangefinder:distance_cm_orient(orientation) end
 
 -- desc

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -204,12 +204,14 @@ ap_object AP_RangeFinder_Backend method orientation Rotation'enum
 ap_object AP_RangeFinder_Backend method type uint8_t
 ap_object AP_RangeFinder_Backend method status uint8_t
 ap_object AP_RangeFinder_Backend method handle_script_msg boolean float'skip_check
+ap_object AP_RangeFinder_Backend method handle_script_msg_ex boolean float'skip_check float'skip_check
 
 singleton RangeFinder depends (!defined(HAL_BUILD_AP_PERIPH) || defined(HAL_PERIPH_ENABLE_RANGEFINDER))
 singleton RangeFinder rename rangefinder
 singleton RangeFinder method num_sensors uint8_t
 singleton RangeFinder method has_orientation boolean Rotation'enum ROTATION_NONE ROTATION_MAX-1
-singleton RangeFinder method distance_cm_orient uint16_t Rotation'enum ROTATION_NONE ROTATION_MAX-1
+singleton RangeFinder method distance_cm_orient_ex void Rotation'enum ROTATION_NONE ROTATION_MAX-1 uint16_t'Ref int8_t'Ref
+singleton RangeFinder method distance_cm_orient_ex rename distance_cm_orient
 singleton RangeFinder method max_distance_cm_orient uint16_t Rotation'enum ROTATION_NONE ROTATION_MAX-1
 singleton RangeFinder method min_distance_cm_orient uint16_t Rotation'enum ROTATION_NONE ROTATION_MAX-1
 singleton RangeFinder method ground_clearance_cm_orient uint16_t Rotation'enum ROTATION_NONE ROTATION_MAX-1

--- a/libraries/AP_Scripting/tests/rngfnd_quality_test.lua
+++ b/libraries/AP_Scripting/tests/rngfnd_quality_test.lua
@@ -1,0 +1,209 @@
+
+
+
+-- The UPDATE_PERIOD_MS is the time between when a distance is set and
+-- it is read. There is a periodic task that copies the set distance to
+-- a place it is read from. If UPDATE_PERIOD_MS is too short this periodic
+-- task might not get a chance to run. A value of 25 seems to be too quick.
+local UPDATE_PERIOD_MS = 50
+local TIMEOUT_MS = 5000
+local RANGEFINDER_TYPE_LUA = 36.0
+local RANGEFINDER_ORIENTATION = 25 -- down
+
+
+local function send(str)
+    gcs:send_text(3, string.format("RQTL %s", str))
+end
+local function send_success()
+    send("Complete: !!SUCCESS!!")
+end
+local function send_failure(err_str)
+    send(string.format("Complete: !!FAILURE!!: %s", err_str))
+end
+
+
+
+---@type AP_RangeFinder_Backend_ud
+local device_backend
+
+local function dist_overflow_failfunc(dist_m_in, dist_cm_out, signal_quality_pct_in, signal_quality_pct_out)
+    local max_dist_cm = rangefinder:max_distance_cm_orient(device_backend:orientation())
+     if dist_m_in > max_dist_cm / 100.0 then
+        if signal_quality_pct_in < 0 and signal_quality_pct_out ~= -1 then
+            return true
+        end
+        if signal_quality_pct_in >= 0 and signal_quality_pct_out ~= 0 then
+            return true
+        end
+        if math.abs(dist_cm_out - max_dist_cm) > 1.0e-8 then
+            return true
+        end
+        return false
+    end
+    return
+end
+
+local function dist_underflow_failfunc(dist_m_in, dist_cm_out, signal_quality_pct_in, signal_quality_pct_out)
+    local min_dist_cm = rangefinder:min_distance_cm_orient(device_backend:orientation())
+    if dist_m_in < min_dist_cm / 100.0 then
+        if signal_quality_pct_in < 0 and signal_quality_pct_out ~= -1 then
+            return true
+        end
+        if signal_quality_pct_in >= 0 and signal_quality_pct_out ~= 0 then
+            return true
+        end
+        if math.abs(dist_cm_out - min_dist_cm) > 1.0e-8 then
+            return true
+        end
+        return false
+    end
+    return
+end
+
+local function dist_equal_failfunc(dist_m_in, dist_cm_out, signal_quality_pct_in, signal_quality_pct_out)
+    if dist_cm_out ~= dist_m_in * 100.0 then
+        return true
+    end
+    if signal_quality_pct_in < 0 and signal_quality_pct_out == -1 then
+        return false
+    end
+    if signal_quality_pct_in > 100 and signal_quality_pct_out == -1 then
+        return false
+    end
+    if math.floor(signal_quality_pct_in) == signal_quality_pct_out then
+        return false
+    end
+    return true
+end
+
+local function simple_test_funcfact(dist_m_in, signal_quality_pct_in)
+    return function(test_idx)
+        if not device_backend:handle_script_msg_ex(dist_m_in, signal_quality_pct_in) then
+            return
+        end
+        return function()
+            local dist_cm_out, signal_quality_pct_out = rangefinder:distance_cm_orient(RANGEFINDER_ORIENTATION)
+
+            send(string.format("Test %i dist in_m: %.2f out_cm: %.2f, signal_quality_pct in: %.1f out: %.1f",
+                test_idx, dist_m_in, dist_cm_out, signal_quality_pct_in, signal_quality_pct_out))
+
+            local failed
+
+            failed = dist_overflow_failfunc(dist_m_in, dist_cm_out, signal_quality_pct_in, signal_quality_pct_out) 
+            if failed ~= nil then
+                if failed then
+                    return string.format("Test %i failed dist_overflow", test_idx)
+                end
+                return
+            end
+
+            failed = dist_underflow_failfunc(dist_m_in, dist_cm_out, signal_quality_pct_in, signal_quality_pct_out) 
+            if failed ~= nil then
+                if failed then
+                    return string.format("Test %i failed dist_underflow", test_idx)
+                end
+                return
+            end
+
+            failed = dist_equal_failfunc(dist_m_in, dist_cm_out, signal_quality_pct_in, signal_quality_pct_out) 
+            if failed ~= nil then
+                if failed then
+                    return string.format("Test %i failed dist_equal", test_idx)
+                end
+                return
+            end
+        end
+    end
+end
+
+
+local tests = {
+    simple_test_funcfact(20.0, -1),
+    simple_test_funcfact(21.0, 0),
+    simple_test_funcfact(22.0, 50),
+    simple_test_funcfact(23.0, 100),
+    simple_test_funcfact(24.0, 101),
+    simple_test_funcfact(25.0, -3),
+    simple_test_funcfact(26.0, 10000),
+    simple_test_funcfact(27.0, 1.5),
+    simple_test_funcfact(28.0, -0.5),
+    simple_test_funcfact(29.0, 99.5),
+    simple_test_funcfact(-1.0, 50),
+    simple_test_funcfact(-1.0, -1),
+    simple_test_funcfact(500.0, 50),
+    simple_test_funcfact(500.0, -1),
+}
+
+-- Record the start time so we can timeout if it takes to long to initialize.
+local time_start_ms = millis():tofloat()
+
+-- Forward declare the update functions.
+local prepare_test
+local begin_test
+local eval_test
+
+local eval_func
+local test_idx = 0
+
+prepare_test = function()
+    -- Check for timeout while initializing
+    if millis():tofloat() - time_start_ms > TIMEOUT_MS then
+        send_failure("Timeout while trying to initialize")
+        return
+    end
+    if Parameter('RNGFND1_TYPE'):get() ~= 36 then
+        send_failure("LUA driver not enabled")
+        return
+    end
+    if rangefinder:num_sensors() < 1 then
+        send_failure("LUA driver not connected")
+        return
+    end
+    device_backend = rangefinder:get_backend(0)
+    if not device_backend then
+        send_failure("Range Finder 1 does not exist")
+        return
+    end
+    if (device_backend:type() ~= RANGEFINDER_TYPE_LUA) then
+        send_failure("Range Finder 1 is not a LUA driver")
+        return
+    end
+
+
+    -- Wait until the prearm check passes. This ensures that the system is mostly initialized
+    -- before starting the tests.
+    if not arming:pre_arm_checks() then
+        return prepare_test, UPDATE_PERIOD_MS
+    end
+
+    -- start the test
+    return begin_test()
+end
+
+begin_test = function()
+    test_idx = test_idx + 1
+    if test_idx > #tests then
+        send_success()
+        return
+    end
+
+    eval_func = tests[test_idx](test_idx)
+    if not eval_func then
+        send_failure(string.format("Test %i failed to initialize", test_idx))
+    end
+
+    return eval_test, UPDATE_PERIOD_MS
+end
+
+eval_test = function()
+    local err_str = eval_func()
+    if not err_str then
+        return begin_test()
+    end
+    send_failure(string.format("Test %i failed with error: %s", test_idx, err_str))
+    return
+end
+
+send("Loaded rngfnd_quality_test.lua")
+
+return prepare_test, UPDATE_PERIOD_MS


### PR DESCRIPTION
This PR adds support for signal_guality to the lua range finder driver. This involves extending the lua interface to get signal_quality for scripts that would like to make decisions based on range finder measurement signal_quality. It also involves setting signal_quality for lua range finder device drivers. 

Here are a few scenarios where the functionality in this PR would be useful:
- A script wants to get the signal_quality of a distance measurement provided by an attached Range Finder.
- A lua hardware driver could be developed for a range finder device that provides signal_quality data.
- A sitl lua driver could be developed that provides synthetic signal_quality data for testing other ardupilot algorithms

Every range finder distance measurement can be accompanied by a signal_quality_pct value. This value ranges from 0 to 100 and provides a mechanism for the hardware to indicate how good this measurement is. Better measurements have higher signal_quality values but the particular signal_quality value is arbitrary and dependent on the whims of the range finder driver. A signal_quality value of -1 means there is no signal_quality data with this measurement.

This PR includes:
- modifications to the LUA interface
- modifications to the Range Finder front end
- modifications to the LUA Range Finder backend
- tests - implemented in LUA and driven from Tools/autotest/ardusub.py

Some questions posed and potentially answered incorrectly by this PR:
- How should an existing lua interface be extended?
- Can the returned distance be trimmed to the min and max valid values?
- What is the right data type for signal_quality_pct?
- Can distance and signal_quality get out of sync? distance is stored in the state and signal_quality is a virtual function. Issues were detected in the auto-test. The auto-test had to add delay to ensure they stayed synced.
- How does signal_quality relate to status?
